### PR TITLE
reproduce: diamond dependency parsing bug

### DIFF
--- a/infra/dev/my-project/iam/permissions/secret-access/terragrunt.hcl
+++ b/infra/dev/my-project/iam/permissions/secret-access/terragrunt.hcl
@@ -21,3 +21,4 @@ inputs = {
   role         = "roles/secretmanager.secretAccessor"
   # trigger: reproduce diamond dependency bug
 }
+# trigger: diamond dependency


### PR DESCRIPTION
Reproduction case for diggerhq/digger#2628.

`secret-access` depends on both `admin-group` directly and via `my-project`, creating a diamond dependency. With `cascadeDependencies: true` and `dependsOnOrdering: true` this should trigger:

```
failed to create project dependency graph: edge already exists
```