### PR TITLE
Repro: approvals=[] when PR has >30 reviews (digger GetApprovals pagination)

### DIFF
--- a/repro-approvals-pagination.md
+++ b/repro-approvals-pagination.md
@@ -1,0 +1,8 @@
+# Repro: digger approvals=[] when PR has >30 reviews
+
+This PR receives 31 COMMENTED reviews (simulating a per-file review bot),
+then one real APPROVED review.
+
+Digger GetApprovals (libs/ci/github/github.go:248) calls ListReviews once
+with empty ListOptions{} -> GitHub default per_page=30, no pagination loop.
+The approval lands on page 2 and is never fetched: approvals=[], approval_teams=[].


### PR DESCRIPTION
Reproduction for the Hard Rock issue: 31 automated COMMENTED reviews posted first (simulating a per-file review bot), then a real APPROVED review. Digger's GetApprovals (libs/ci/github/github.go:248) fetches only the first 30 reviews — empty ListOptions{}, no pagination — so it never sees the approval: approvals=[], approval_teams=[].